### PR TITLE
Improve English Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,70 @@
-# CONTRIBUTING
+Language: :us: - :[cn](./CONTRIBUTING_zh.md):
 
-## 代码规范
+# Contributing to KafkaCenter
+We are very happy that you want to contribute to our project, awesome!
 
-### 规约
+Below are some guidelines to get you started. Feel free to reach out in case anything is unclear.
 
-#### API设计
+## Code Specifications
 
-针对需要和后端交互的场景，后端API应与前端路由地址保持一致，如果一个页面存在多个网络请求按树形结构划分，例如：
-Monitor>Topic模块
+### API Design Principles
+For scenarios that require interaction with the backend, the backend endpoint should be consistent with the frontend routing address. If there are different requests for one page, these should be under the same parent in the tree. 
+
+Here's an example for the *Monitoring* module:
+
+Monitor > Topic:
 ```
-前端路由：/#/monitor/topic
+Frontend routing：/#/monitor/topic
+
 API:
-- 查询所有Topic /monitor/topic
+- Search all topics: /monitor/topic
 ```
 
-Monitor>Alert模块
+Monitor > Alert:
 ```
-前端路由：/#/monitor/alert
+Frontend routing：/#/monitor/alert
+
 API:
-- 查询所有alert /monitor/alert
-- 新增alert /monitor/alert/add
+- Search all alerts: /monitor/alert
+- Add alert: /monitor/alert/add
 ```
 
-### 前端规范
+### Frontend Specifications
+- File line break: `LF`
+- `ESLint` must be used
+- If a subcomponent is used across multiple components, it must be moved up in the hierarchy and used jointly
 
-- 文件换行符`LF`
-- 必须安装ESLint,检查代码规范
-- 能公用组件，必须提升成公用组件
+### Backend Specifications
+Please adhere to the [Alibaba-Java-Coding-Guidelines](https://alibaba.github.io/Alibaba-Java-Coding-Guidelines/).
 
-### 后端代码规范
+## Frontend Development
+[Visual Studio Code](https://code.visualstudio.com/) is recommended for development on the frontend. Since the frontend of the project depends on the backend service, you can either start the backend services locally or modify package.json `proxyConfig` in `package.json` to an address where the backend services are available.
 
-使用[阿里java 规范手册约束](https://alibaba.github.io/Alibaba-Java-Coding-Guidelines/)
+Have a look at the separate [frontend README](./KafkaCenter-Frontend/README.md) for more details.
 
-## 前端开发
+### 1. Install *nodejs*
+*Self-explanatory...*
 
-推荐使用VS Code 开发前端代码,前端项目依赖后端服务，可以先启动后端服务，或者修改`package.json`中`proxyConfig`，将其中的地址改为可用的后端服务地址。更多内容[详见地址](./KafkaCenter-Frontend/README.md)
-
-### 安装node
-
-略
-
-### 运行
-
+### 2. Run
 ```
 $ cd KafkaCenter/KafkaCenter-Frontend
 $ npm install
 $ npm start
 ```
 
-### 发布
-
+### 3. Release
 ```
 $ cd KafkaCenter/KafkaCenter-Frontend
 $ npm run build
 ```
-编译后的代码会发布到`../KafkaCenter-Core/src/main/resources/static`
-## 后端开发
+The compiled code will be posted to: `../KafkaCenter-Core/src/main/resources/static`
 
-### 安装jdk 11/maven3.5+
+## Backend Development
 
-略
+### 1. Install *jdk 11* & *maven3.5+*
+*Self-explanatory...*
 
-### 编译/运行
-
+### 2. Compile / Run
 ```
 $ cd KafkaCenter
 $ mvn clean package -Dmaven.test.skip=true
@@ -70,8 +72,7 @@ $ cd KafkaCenter\KafkaCenter-Core\target
 $ java -jar KafkaCenter-Core-0.0.1-SNAPSHOT.jar
 ```
 
-### 发布
-
+### 3. Release
 ```
 $ cd KafkaCenter
 $ mvn clean package -Dmaven.test.skip=true

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,0 +1,80 @@
+Language: :[us](./CONTRIBUTING.md): - :cn:
+
+# CONTRIBUTING
+
+## 代码规范
+
+### 规约
+
+#### API设计
+
+针对需要和后端交互的场景，后端API应与前端路由地址保持一致，如果一个页面存在多个网络请求按树形结构划分，例如：
+Monitor>Topic模块
+```
+前端路由：/#/monitor/topic
+API:
+- 查询所有Topic /monitor/topic
+```
+
+Monitor>Alert模块
+```
+前端路由：/#/monitor/alert
+API:
+- 查询所有alert /monitor/alert
+- 新增alert /monitor/alert/add
+```
+
+### 前端规范
+
+- 文件换行符`LF`
+- 必须安装ESLint,检查代码规范
+- 能公用组件，必须提升成公用组件
+
+### 后端代码规范
+
+使用[阿里java 规范手册约束](https://alibaba.github.io/Alibaba-Java-Coding-Guidelines/)
+
+## 前端开发
+
+推荐使用VS Code 开发前端代码,前端项目依赖后端服务，可以先启动后端服务，或者修改`package.json`中`proxyConfig`，将其中的地址改为可用的后端服务地址。更多内容[详见地址](./KafkaCenter-Frontend/README.md)
+
+### 安装node
+
+略
+
+### 运行
+
+```
+$ cd KafkaCenter/KafkaCenter-Frontend
+$ npm install
+$ npm start
+```
+
+### 发布
+
+```
+$ cd KafkaCenter/KafkaCenter-Frontend
+$ npm run build
+```
+编译后的代码会发布到`../KafkaCenter-Core/src/main/resources/static`
+## 后端开发
+
+### 安装jdk 11/maven3.5+
+
+略
+
+### 编译/运行
+
+```
+$ cd KafkaCenter
+$ mvn clean package -Dmaven.test.skip=true
+$ cd KafkaCenter\KafkaCenter-Core\target
+$ java -jar KafkaCenter-Core-0.0.1-SNAPSHOT.jar
+```
+
+### 发布
+
+```
+$ cd KafkaCenter
+$ mvn clean package -Dmaven.test.skip=true
+```

--- a/KafkaCenter-Core/src/main/resources/application.properties
+++ b/KafkaCenter-Core/src/main/resources/application.properties
@@ -1,52 +1,88 @@
+# ----------------------------------------------
+# MAIN APPLICATION CONFIG
+
+# url and port where application is published
 server.port=8080
+public.url=http://localhost:8080
+
+# enable/disable debug logging level
 debug=false
-# 设置session timeout为6小时
+
+# session timeout in seconds (21600 = 6 hours)
 server.servlet.session.timeout=21600
+
+# admin user/password to manage KafkaCenter
 spring.security.user.name=admin
 spring.security.user.password=admin
+
+# url and user/password for mysql database
+# if remote, make sure the user has adequate privileges (google "mysql grant privileges")
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/kafka_center?useUnicode=true&characterEncoding=utf-8
 spring.datasource.username=root
 spring.datasource.password=123456
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.type=com.zaxxer.hikari.HikariDataSource
-spring.datasource.hikari.minimum-idle=5
-spring.datasource.hikari.maximum-pool-size=15
-spring.datasource.hikari.pool-name=KafkaCenterHikariCP
-spring.datasource.hikari.max-lifetime =30000
-spring.datasource.hikari.connection-test-query=SELECT 1
-management.health.defaults.enabled=false
 
-public.url=http://localhost:8080
-connect.url=http://localhost:8000/#/
-system.topic.ttl.h=16
 
+# ----------------------------------------------
+# MONITOR
+
+# enable/disable functionality
 monitor.enable=true
+
+# statistic collection frequency
 monitor.collect.period.minutes=5
+
+# elasticsearch config
 monitor.elasticsearch.hosts=localhost:9200
 monitor.elasticsearch.index=kafka_center_monitor
-#是否启用收集线程指定集群收集
-monitor.collector.include.enable=false
-#收集线程指定location，必须属于remote.locations之中
-monitor.collector.include.location=dev
-collect.topic.enable=true
-collect.topic.period.minutes=10
-# remote的功能是为了提高lag查询和收集，解决跨location网络延迟问题
-remote.query.enable=false
-remote.hosts=gqc@localhost2:8080
-remote.locations=dev,gqc
-#发送consumer group的lag发送给alert service
+
+
+# ----------------------------------------------
+# ALERTS
+
+# enable/disable functionality to send consumer group lag alerts
 alert.enable=false
-alert.dispause=2
+
+# url of alert service (leave empty for regular internal application)
 alert.service=
+
+# default time window and threshold 
+alert.dispause=2
+
+# default threshold
 alert.threshold=1000
+
+# environment variable included in alerts
 alter.env=other
-#是否开启邮件功能,true:启用，false:禁用
+
+
+# ----------------------------------------------
+# EMAILS
+
+# enable/disable functionality to trigger emails for alerts
 mail.enable=false
+
+# configuration of external mail host
 spring.mail.host=
 spring.mail.username=KafkaCenter@xaecbd.com
-# oauth2
+
+
+# ----------------------------------------------
+# KAFKA CONNECT
+
+# url where kafka connect is installed
+connect.url=http://localhost:8000/#/
+
+
+# ----------------------------------------------
+# OAUTH2 KAFKACENTER LOGIN
+
+# enable/disable functionality to log into application via external oauth service
 generic.enabled=false
+
+# name of service on login page
 generic.name=oauth2 Login
+
+# settings of external oauth service
 generic.auth_url=
 generic.token_url=
 generic.redirect_utl=
@@ -54,3 +90,38 @@ generic.api_url=
 generic.client_id=
 generic.client_secret=
 generic.scopes=
+
+
+# ----------------------------------------------
+# VARIOUS ADVANCED CONFIGS
+
+# default kafka topic retention time
+system.topic.ttl.h=16
+
+# enable/disable default spring boot actuator health indicators
+management.health.defaults.enabled=false
+
+# hikari connection pool configurations 
+spring.datasource.type=com.zaxxer.hikari.HikariDataSource
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.maximum-pool-size=15
+spring.datasource.hikari.pool-name=KafkaCenterHikariCP
+spring.datasource.hikari.max-lifetime=30000
+spring.datasource.hikari.connection-test-query=SELECT 1
+
+# mysql driver
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# enable/disable collecting list of kafka topics regularly, and set interval of collection
+collect.topic.enable=true
+collect.topic.period.minutes=10
+
+# enable/disable that collection threads only collect metrics of certain cluster locations
+# the location specified must be one of remote.locations below
+monitor.collector.include.enable=false
+monitor.collector.include.location=dev
+
+# enable remote querying to improve lag collection behaviour, solving problems induced by latency between differenct locations
+remote.query.enable=false
+remote.hosts=gqc@localhost2:8080
+remote.locations=dev,gqc

--- a/KafkaCenter-Core/src/main/resources/application_zh.properties
+++ b/KafkaCenter-Core/src/main/resources/application_zh.properties
@@ -1,0 +1,56 @@
+server.port=8080
+debug=false
+# 设置session timeout为6小时
+server.servlet.session.timeout=21600
+spring.security.user.name=admin
+spring.security.user.password=admin
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/kafka_center?useUnicode=true&characterEncoding=utf-8
+spring.datasource.username=root
+spring.datasource.password=123456
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.type=com.zaxxer.hikari.HikariDataSource
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.maximum-pool-size=15
+spring.datasource.hikari.pool-name=KafkaCenterHikariCP
+spring.datasource.hikari.max-lifetime =30000
+spring.datasource.hikari.connection-test-query=SELECT 1
+management.health.defaults.enabled=false
+
+public.url=http://localhost:8080
+connect.url=http://localhost:8000/#/
+system.topic.ttl.h=16
+
+monitor.enable=true
+monitor.collect.period.minutes=5
+monitor.elasticsearch.hosts=localhost:9200
+monitor.elasticsearch.index=kafka_center_monitor
+#是否启用收集线程指定集群收集
+monitor.collector.include.enable=false
+#收集线程指定location，必须属于remote.locations之中
+monitor.collector.include.location=dev
+collect.topic.enable=true
+collect.topic.period.minutes=10
+# remote的功能是为了提高lag查询和收集，解决跨location网络延迟问题
+remote.query.enable=false
+remote.hosts=gqc@localhost2:8080
+remote.locations=dev,gqc
+#发送consumer group的lag发送给alert service
+alert.enable=false
+alert.dispause=2
+alert.service=
+alert.threshold=1000
+alter.env=other
+#是否开启邮件功能,true:启用，false:禁用
+mail.enable=false
+spring.mail.host=
+spring.mail.username=KafkaCenter@xaecbd.com
+# oauth2
+generic.enabled=false
+generic.name=oauth2 Login
+generic.auth_url=
+generic.token_url=
+generic.redirect_utl=
+generic.api_url=
+generic.client_id=
+generic.client_secret=
+generic.scopes=

--- a/README.md
+++ b/README.md
@@ -1,64 +1,92 @@
-Language: :us::[cn](./README_zh.md): 
+Language: :us: - :[cn](./README_zh.md):
 # KafkaCenter
 
 ![](https://img.shields.io/badge/java-1.8+-green.svg)
 ![](https://img.shields.io/badge/maven-3.5+-green.svg)
 
-KafkaCenter is a unified one-stop platform for Kafka cluster management and maintenance, producer / consumer monitoring, and use of ecological components.
-- [KafkaCenter](#kafkacenter)
+KafkaCenter is a unified one-stop platform for Kafka cluster management and maintenance, producer/consumer monitoring, and use of ecological components.
+
+**Table of Contents**
+  - [Why Should I Use KafkaCenter?](#why-should-i-use-kafkacenter)
   - [Main Features](#main-features)
+  - [Application Config](#application-config)
   - [Getting Started](#getting-started)
-    - [Building and Running KafkaCenter, and/or Contributing Code](#building-and-running-kafkacenter-andor-contributing-code)
+    - [1. Init](#1-init)
+    - [2. Run](#2-run)
+    - [3. Access UI](#3-access-ui)
+  - [Building KafkaCenter and/or Contributing Code](#building-kafkacenter-andor-contributing-code)
   - [Documentation](#documentation)
-  - [TODO](#todo)
   - [Changelog](#changelog)
   - [Questions? Problems? Suggestions?](#questions-problems-suggestions)
+
+
+## Why Should I Use KafkaCenter?
+
+You have a Kafka cluster* and want to
+- monitor producers and consumers with graphs and the ability to easily configure email alerts for thresholds
+- let your users request topics and monitor them themselves in a simple web UI
+- access the Kafka ecosystem (Kafka, KSQL, Kafka Connect, Kafka Manager) in one combined UI
+
+All you need is a MySQL DB in the background where KafkaCenter can store it's configuration. If you want to use the monitoring functionalities, you additionally need an Elasticsearch installation.
+Then, just download our Docker image (see HowTo below) and off you go!
+
+*\* Note: KafkaCenter does not yet support authenticating to a secured Kafka cluster (SASL or OAuth), we're working on it though.*
+
 
 ## Main Features
 ![avatar](docs/images/kafka-center.png)
 ![avatar](docs/images/screenshot.png)
-- **Home**->
-view kafka cluster list and monitoring information
-- **Topic**->
-Users can view their own topics in this module, apply for new topics, mock and consumption data .
-- **Monitor**->
-Users can view the production and consumption of topics in this module, and set warning information for consumption delays.
-- **Kafka Connect**->
-Users able to quickly create their own Connect jobs and maintain their own connect.
-- **KSQL**->
-Users able to quickly create their own KSQL jobs and maintain their jobs.
-- **Approve**->
-This module is mainly used as a common user application to create Topic, operations administrator for approval.
-- **Setting**->
-The administrator maintains User, Team.
-- **Kafka Manager**->
-maintain kafka cluster information.
-## Config
-[application.properties](KafkaCenter-Core/src/main/resources/application.properties)
+
+- **Home** -> Overview of all configured Kafka clusters as well as high-level monitoring information.
+- **Favorites** -> Direct access to the monitoring statistics of your favorite topics.
+- **Topic** -> View your own topics or *apply for new topics. You can also both consume messages and mock new records via web UI into your topics here!*
+- **Monitor** -> Statistics about production and consumption of your topics. *There is an additional possibility to configure alerts (which optionally trigger emails) for arbitrary consumption delay thresholds here!*
+- **Kafka Connect** -> Create and maintain your own Kafka Connect jobs (needs an external Kafka Connect service to connect to).
+- **KSQL** -> Create and maintain your own KSQL jobs (needs an external KQL service to connect to).
+- **Approve** -> Users can view their topic creation requests here, administrators can manage and approve the requests.
+- **Settings** -> Maintain users and teams (accessible by administrators only). *You can also use an external OAuth solution for the user management.*
+- **Kafka Manager** -> Maintain Kafka cluster information (embedded UI from the popular open-source tool [Kafka Manager](https://github.com/yahoo/CMAK)).
+
+
+## Application Config
+The main application configuration is done via the [application.properties](KafkaCenter-Core/src/main/resources/application.properties).
+
+
 ## Getting Started
 
-**Important**: Before you begin, make sure you have installed **mysql**.
+**Important**: The application **needs a MySQL database** to store all configurations. Before you begin, make sure that you have it either installed on the same host or that there's an instance available somewhere else. The exact location can then be configured via the `spring.datasource.url` inside the `application.properties`. (There is *no* MySQL service included in the Docker image.)
 
-resource|dependencies|use
+Resource|Dependencies|Use
 ---|---|---
-mysql|must|Configuration information is stored in **mysql**
-elasticsearch(7.0+)|optional|Monitoring information, such as cluster metirc, consumption lag visualization, etc.
-email server|optional|Apply, approval, warning e-mail alert
-### 1.init
-#### create database and table
-execute [table_script.sql](KafkaCenter-Core/sql/table_script.sql)
-#### edit config
-down [application.properties](KafkaCenter-Core/src/main/resources/application.properties),edit config.
-### 2.run
-- Docker run(**recommend**)
+MySQL|must|Stores all configuration information (users, teams, clusters, etc.)
+Elasticsearch (7.0+)|optional|Stores monitoring information (cluster metrics, consumption lag visualization, etc.)
+Email server|optional|Email notifications (topic requests & approvals, configured consumer alerts)
 
+### 1. Init
+
+#### Create database and table
+Execute the provided [table_script.sql](KafkaCenter-Core/sql/table_script.sql) on your MySQL instance to create the database and all necessary tables.
+
+#### Edit config
+Download the provided [application.properties](KafkaCenter-Core/src/main/resources/application.properties) example and adapt the config to your needs.
+
+
+### 2. Run
+
+#### Option A (**recommended**): Docker
+
+The following command assumes that you have your adapted `application.properties` inside the same folder:
 ```
-docker run -d -p 8080:8080 --name KafkaCenter -v ${PWD}/application.properties:/opt/app/kafka-center/config/application.properties xaecbd/kafka-center:2.1.0
+docker run -d \
+  -p 8080:8080 \
+  --name KafkaCenter \
+  -v ${PWD}/application.properties:/opt/app/kafka-center/config/application.properties \ 
+  xaecbd/kafka-center:2.1.0
 ```
 
-- Local run
+#### Option B: Local
 
-**Important**: Before you begin, make sure you have installed **jre1.8** and download the release package in the release.
+**Important**: Make sure you have installed a **JRE 8** or higher and download the most recent [release package](https://github.com/xaecbd/KafkaCenter/releases).
 ```
 $ git clone https://github.com/xaecbd/KafkaCenter.git
 $ cd KafkaCenter
@@ -67,14 +95,15 @@ $ cd KafkaCenter\KafkaCenter-Core\target
 $ java -jar KafkaCenter-Core-2.1.0-SNAPSHOT.jar
 ```
 
-### 3.view system
-view`http://localhost:8080`,default administrator ：**admin/admin**
-### Building and Running KafkaCenter, and/or Contributing Code
 
-You might want to build KafkaCenter locally to contribute some code, test out the latest features, or try
-out an open PR:
+### 3. Access UI
+The application UI is published on port *8080*. Visit `http://localhost:8080` (or insert the IP/URL of the host you deployed on) and log in with the default administrator：**user/pw = admin/admin**
 
-- [CONTRIBUTING.md](./CONTRIBUTING.md) will help you get KafkaCenter up and running.
+
+## Building KafkaCenter and/or Contributing Code
+
+We're happy if you want to play around and build KafkaCenter locally, or even get involved in shaping and developing KafkaCenter further. The [Contributing Guidelines](./CONTRIBUTING.md) will help to get you started.
+
 
 ## Documentation
 
@@ -82,16 +111,15 @@ For more information, see the README in [KafkaCenter/docs](./docs).<br/>
 For information about user guide the documentation, see the UserGuide in [KafkaCenter/docs/UserGuide](./docs/UserGuide.md)  
 For information about module the documentation, see the Module in [KafkaCenter/docs/Module](./docs/Module.md).<br/>
 For information about kafka connect ui, see docs in [KafkaConnectUi](./docs/KafkaConnectUi.md).
-## TODO
 
-See [TODO List](https://github.com/xaecbd/KafkaCenter/projects/1)
+*Note that we open-sourced our tool very recently and did not translate all the documents to English yet. (We are happy about contributions in this area as well if you're motivated!)*
+
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md)
+See the separate [Changelog](./CHANGELOG.md).
+
 
 ## Questions? Problems? Suggestions?
 
-- If you've found a bug or want to request a feature, please create a [Issue](https://github.com/xaecbd/KafkaCenter/issues/new).
-Please check to make sure someone else hasn't already created an issue for the same topic.
-- Need help using KafkaCenter? Ask EC Bigdata Team member.
+If you found a bug, want to request a feature or have a question, please create an [issue](https://github.com/xaecbd/KafkaCenter/issues/new). Try to make sure someone else hasn't already created an issue for the same topic beforehand.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then, just download our Docker image (see HowTo below) and off you go!
 
 
 ## Application Config
-The main application configuration is done via the [application.properties](KafkaCenter-Core/src/main/resources/application.properties).
+The main application configuration is done in a central `application.properties` file. Have look at our [detailed example here](KafkaCenter-Core/src/main/resources/application.properties).
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You have a Kafka cluster* and want to
 - let your users request topics and monitor them themselves in a simple web UI
 - access the Kafka ecosystem (Kafka, KSQL, Kafka Connect, Kafka Manager) in one combined UI
 
-All you need is a MySQL DB in the background where KafkaCenter can store it's configuration. If you want to use the monitoring functionalities, you additionally need an Elasticsearch installation.
+All you need is a MySQL DB in the background where KafkaCenter can store its configuration. If you want to use the monitoring functionalities, you additionally need an Elasticsearch installation.
 Then, just download our Docker image (see HowTo below) and off you go!
 
 *\* Note: KafkaCenter does not yet support authenticating to a secured Kafka cluster (SASL or OAuth), we're working on it though.*

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,7 +40,7 @@ KafkaCenter是Kafka 集群管理和维护，生产/消费监控，生态组件�
 此模块用于管理员对集群的正常维护操作。
 
 ## 配置
-[application.properties](KafkaCenter-Core/src/main/resources/application.properties)
+[application.properties](KafkaCenter-Core/src/main/resources/application_zh.properties)
 
 ## 快速开始
 
@@ -55,7 +55,7 @@ elasticsearch(7.0+)|非必须|监控信息，例如集群metirc,消费lag可视�
 #### 创建数据库及表
 在数据库中执行[table_script.sql](KafkaCenter-Core/sql/table_script.sql)
 #### 初始化配置
-下载[application.properties](KafkaCenter-Core/src/main/resources/application.properties),按自己需求修改相应的配置
+下载[application.properties](KafkaCenter-Core/src/main/resources/application_zh.properties),按自己需求修改相应的配置
 ### 2.其次运行服务
 - Docker run(**推荐**)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-Language: :[us](./README.md)::cn:
+Language: :[us](./README.md): - :cn:
 
 # KafkaCenter
 
@@ -82,7 +82,7 @@ $ java -jar KafkaCenter-Core-2.1.0-SNAPSHOT.jar
 You might want to build KafkaCenter locally to contribute some code, test out the latest features, or try
 out an open PR:
 
-- [CONTRIBUTING.md](CONTRIBUTING.md) will help you get KafkaCenter up and running.
+- [CONTRIBUTING_zh.md](CONTRIBUTING_zh.md) will help you get KafkaCenter up and running.
 
 ## 文档
 


### PR DESCRIPTION
Improve English versions of most important parts of documentation, as discussed in issue https://github.com/xaecbd/KafkaCenter/issues/47:
- Improve spelling and content of main English `README.md`
- Add extended, English version of `application.properties` as default example (keep Chinese one as separate `_zh` version)
- Translate main contributing guidelines `CONTRIBUTING.md` to English and move Chinese version to `_zh`